### PR TITLE
lsコマンド作成

### DIFF
--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -18,14 +18,27 @@ def run_app
   Dir.foreach(path || '.') do |d|
     items << d
   end
-
-  file_name(items, a, r) 
+  
+  files = apply_order_option(items, a, r)
+  l ? list_detail(files) : list_name(files) 
 end
 
-def file_name(items, a, r)
+def apply_order_option(items, a, r)
   files = items.sort.sort { |a, b| a.gsub(/\./, '').downcase <=> b.gsub(/\./, '').downcase }
   files.delete_if { |f| f.match?(/^\..*/) } if !a
   files.reverse! if r  
+  files
+end
+ 
+def list_detail(files)
+  stat = File.stat("/home/kasai441/.b*")
+  puts stat.dev
+  puts stat.size
+  puts "0%o" % stat.mode
+  puts stat.mode
+end
+
+def list_name(files)
   cols = divide_to_cols(files)
   rows = cols_to_rows(cols)
   rows.each { |e| puts e.join('  ') }
@@ -75,11 +88,3 @@ def sizeup_to_max(cols)
 end
 
 run_app
-
-def stat
-  stat = File.stat("/home/kasai441/.b*")
-  puts stat.dev
-  puts stat.size
-  puts "0%o" % stat.mode
-  puts stat.mode
-end

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,22 +1,40 @@
-path = ARGV[0]
-p path
-items = []
-files = []
-row = []
-
-# Dir.open(path || '.') do |d|
-#   d.children.each do |item|
-#     items << item
-#   end
-# end
-
-Dir.foreach(path || '.') do |d|
-  items << d
+def run
+  path = ARGV[0]
+  p path
+  items = []
+  # files = []
+  row = []
+  
+  Dir.foreach(path || '.') do |d|
+    items << d
+  end
+  
+  file_name(items,0,0)
 end
 
-# puts 'items'
-# p items.sort.sort { |a, b| a.gsub(/\./, '') <=> b.gsub(/\./, '') }
-# puts 
+def file_name(items, a, r)
+  files = items.sort.sort { |a, b| a.gsub(/\./, '').downcase <=> b.gsub(/\./, '').downcase }
+  
+  cols = divide_to_cols(files)
+  
+  rows = cols_to_rows(cols)
+  
+  rows.each { |e| puts e.join('  ') }
+end
+
+def divide_to_cols(files)
+  cols = files.map { |e| [e] }
+  (2..files.size).each do |n|
+    unless within_width?(cols_to_rows(cols))
+      sliced = files.dup
+      cols.clear
+      cols_size = files.size % n == 0 ? files.size / n : files.size / n + 1
+      cols_size.times { cols << sliced.slice!(0, n) }
+      cols = sizeup_to_max(cols)
+    end
+  end
+  cols
+end
 
 def cols_to_rows(cols)
   rows = []
@@ -47,43 +65,7 @@ def sizeup_to_max(cols)
   result
 end
 
-def divide_to_cols(files)
-  cols = files.map { |e| [e] }
-  (2..files.size).each do |n|
-    unless within_width?(cols_to_rows(cols))
-      sliced = files.dup
-      cols.clear
-      cols_size = files.size % n == 0 ? files.size / n : files.size / n + 1
-      cols_size.times { cols << sliced.slice!(0, n) }
-      cols = sizeup_to_max(cols)
-#       puts "n:#{n}"
-#       p cols
-#       puts
-    end
-  end
-  cols
-end
-
-files = items.sort.sort { |a, b| a.gsub(/\./, '') <=> b.gsub(/\./, '') }
-
-cols = divide_to_cols(files)
-
-# puts 'cols'
-# p cols
-# puts
-# 
-rows = cols_to_rows(cols)
-# 
-# puts 'rows'
-# p rows
-# puts
-
-# p files.map { |e| e.size }.sum
-rows.each { |e| puts e.join('  ') }
-#    printf("%1$s  ", item)
-#    row += "  #{item}" if item.size   
-print "\n"
-p `tput cols`.gsub(/\D/, '').to_i
+run
 
 stat = File.stat("/home/kasai441/#{items[0]}")
 puts stat.dev

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -20,20 +20,20 @@ def run_app
     items << d
   end
   files = apply_order_option(items, a, r)
-  l ? list_detail(path, files) : list_name(files) 
+  l ? list_detail(path, files) : list_name(files)
 end
 
-def apply_order_option(items, a, r)
-  # Debian10/bash では"."及び大文字小文字は無視してソートする
+def apply_order_option(items, a_opt, r_opt)
+  # Debian10/bash では'.'及び大文字小文字は無視してソートする
   files = items.sort { |a, b| a.gsub(/^\./, '').downcase <=> b.gsub(/^\./, '').downcase }
   # -a オプション
-  files.delete_if { |f| f.match?(/^\..*/) } if !a
+  files.delete_if { |f| f.match?(/^\..*/) } unless a_opt
   # -r オプション
-  files.reverse! if r  
+  files.reverse! if r_opt
 
   files
 end
- 
+
 def list_detail(path, files)
   path = to_readable(path)
   data = []
@@ -50,74 +50,68 @@ end
 
 def to_readable(path)
   # デフォルトで現在のフォルダを参照
-  path = './' if !path
-  # ディレクトリの最後に"/"がない場合、補完する
-  path += '/' if !path.match?(/.*\/$/)
+  path ||= './'
+  # ディレクトリの最後に'/'がない場合、補完する
+  path += '/' unless path.match?(%r{.*/$})
   path
 end
 
-def get_stat(path, f)
+def get_stat(path, file)
   # Mac/Ruby3.0.0 でFile.statにシンボリックリンクのパスを入れると例外となる(Debian10/Ruby2.7.1ではならない）その場合File.lstatにパスを入れる
-  # File.lstatで例外となる場合、そのまま実行時例外で異常終了とする
-  begin
-    stat = File.stat(path + f)
-  rescue
-    stat = File.lstat(path + f)
-  end
+  # File.lstatで例外となる場合異常終了とする
+  File.stat(path + file)
+rescue SystemCallError
+  File.lstat(path + file)
 end
 
-def get_data(stat, path, f)
+def get_data(stat, path, file)
   datum = []
   datum << to_char_ftype(stat.ftype) + to_char_mode(stat.mode)
-  #p "0%o" % stat.mode
   datum << stat.nlink
   datum << Etc.getpwuid(stat.uid).name
   datum << get_group_name(stat.uid)
   datum << stat.size
-  datum << stat.mtime.strftime("%b %d %H:%M")
-  datum << (datum[0][0] == 'l' ? "#{f} -> #{File.readlink(path + f)}" : f)
+  datum << stat.mtime.strftime('%b %d %H:%M')
+  datum << (datum[0][0] == 'l' ? "#{file} -> #{File.readlink(path + file)}" : file)
   datum
 end
 
 def to_char_ftype(ftype)
   {
-    "file": "-",
-    "directory": "d",
-    "characterSpecial": "c",
-    "blockSpecial": "b",
-    "fifo": "p",
-    "link": "l",
-    "socket": "s",
-    "unknown": "?"
+    "file": '-',
+    "directory": 'd',
+    "characterSpecial": 'c',
+    "blockSpecial": 'b',
+    "fifo": 'p',
+    "link": 'l',
+    "socket": 's',
+    "unknown": '?'
   }[ftype.to_sym]
 end
 
 def to_char_mode(mode)
-  mode = "0%o" % mode
-  mode = mode[-3, 3]
-  mode = mode.split('').map { |m| which_mode(m) }.join
+  mode = format('0%o', mode)[-3, 3]
+  mode.split('').map { |m| which_mode(m) }.join
 end
 
-def which_mode(m)
+def which_mode(mode)
   {
-    "0": "---",
-    "1": "--x",
-    "2": "-w-",
-    "3": "-wx",
-    "4": "r--",
-    "5": "r-x",
-    "6": "rw-",
-    "7": "rwx"
-  }[m.to_sym]
+    "0": '---',
+    "1": '--x',
+    "2": '-w-',
+    "3": '-wx',
+    "4": 'r--',
+    "5": 'r-x',
+    "6": 'rw-',
+    "7": 'rwx'
+  }[mode.to_sym]
 end
 
 def get_group_name(uid)
   # Linuxで作成したファイルのグループがMacにない場合エラーとなるので、その場合、Macのlsコマンドの動作に準じて'staff'というグループとみなす
-  begin
-    Etc.getgrgid(uid).name
-  rescue
-    'staff'
-  end
+  Etc.getgrgid(uid).name
+rescue ArgumentError
+  'staff'
 end
 
 def to_same_width(data)
@@ -125,9 +119,9 @@ def to_same_width(data)
   cols = convert_cols_rows(data)
   cols = maximize_cols(cols)
   # 改行するほど長いファイル名がある場合に全ての行で改行が起きてしまうのを防ぐため、ファイル名のみ、長さを元のままとして、揃えない
-  cols.last.map! { |c| c.strip }
+  cols.last.map!(&:strip)
   # 入れ替えた行列を再度入れ替えて元に戻す
-  convert_cols_rows(cols)  
+  convert_cols_rows(cols)
 end
 
 def list_name(files)
@@ -143,13 +137,13 @@ def divide_to_cols(files)
   cols = files.map { |e| [e] }
   # ターミナルの幅に収まるまで列数を減らしていく 行数を2から一つずつ増やす
   (2..files.size).each do |rows_num|
-    unless within_display?(convert_cols_rows(cols))
-      sliced = files.dup
-      cols.clear
-      cols_num = (files.size / rows_num.to_f).ceil
-      cols_num.times { cols << sliced.slice!(0, rows_num) }
-      cols = maximize_cols(cols)
-    end
+    break if within_display?(convert_cols_rows(cols))
+
+    sliced = files.dup
+    cols.clear
+    cols_num = (files.size / rows_num.to_f).ceil
+    cols_num.times { cols << sliced.slice!(0, rows_num) }
+    cols = maximize_cols(cols)
   end
   cols
 end
@@ -180,9 +174,10 @@ def maximize_cols(cols)
   cols.each do |col|
     max = col.map { |c| c.to_s.size }.max
     result << col.map do |c|
-      if c.is_a?(String)
+      case c
+      when String
         c + ' ' * (max - c.size)
-      elsif c.is_a?(Integer)
+      when Integer
         ' ' * (max - c.to_s.size) + c.to_s
       end
     end

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -35,6 +35,15 @@ def within_width?(rows)
   true
 end
 
+def sizeup_to_max(cols)
+  result = []
+  cols.map do |col|
+    max = col.map { |c| c.size }.max
+    result << col.map { |c| c + ' ' * (max - c.size) }
+  end
+  result
+end
+
 def divide_to_cols(files)
   cols = files.map { |e| [e] }
   (2..files.size).each do |n|
@@ -43,6 +52,7 @@ def divide_to_cols(files)
       cols.clear
       cols_size = files.size % n == 0 ? files.size / n : files.size / n + 1
       cols_size.times { cols << sliced.slice!(0, n) }
+      cols = sizeup_to_max(cols)
       puts "n:#{n}"
       p cols
       puts

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,0 +1,8 @@
+# Dir.foreach('.') do |item|
+path = ARGV[0]
+Dir.open(path) do |d|
+  d.children.each do |item|
+    print item + "\t"
+  end
+end
+print "\n"

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -57,7 +57,8 @@ def to_readable(path)
 end
 
 def get_stat(path, file)
-  # Mac/Ruby3.0.0 でFile.statにシンボリックリンクのパスを入れると例外となる(Debian10/Ruby2.7.1ではならない）その場合File.lstatにパスを入れる
+  # File.statにシンボリックリンクのパスを入れると例外となる
+  # その場合File.lstatにパスを入れる
   # File.lstatで例外となる場合異常終了とする
   File.stat(path + file)
 rescue SystemCallError
@@ -127,7 +128,7 @@ end
 def list_name(files)
   cols = divide_to_cols(files)
   rows = convert_cols_rows(cols)
-  # Debian10/bashでは各列を最大文字列でそろえ間隔は空白二つ分
+  # Debian10/bashでは間隔は空白二つ分
   rows.each { |e| puts e.join('  ') }
 end
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -39,6 +39,7 @@ def list_detail(path, files)
     datum = []
     stat = File.stat(path + f)
     datum << to_char_ftype(stat.ftype) + to_char_mode(stat.mode)
+    datum << stat.nlink
     datum << stat.uid
     datum << stat.uid
     datum << stat.size

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -19,7 +19,10 @@ def run_app
   Dir.foreach(path || '.') do |d|
     items << d
   end
+
   files = apply_order_option(items, a, r)
+  return if files.size.zero?
+
   l ? list_detail(path, files) : list_name(files)
 end
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,19 +1,22 @@
 path = ARGV[0]
 p path
-path = "#{Dir.home}" if path.nil?
 items = []
 files = []
 row = []
 
-Dir.open(path) do |d|
-  d.children.each do |item|
-    items << item
-  end
+# Dir.open(path || '.') do |d|
+#   d.children.each do |item|
+#     items << item
+#   end
+# end
+
+Dir.foreach(path || '.') do |d|
+  items << d
 end
 
-puts 'items'
-p items.sort { |a, b| a.gsub(/\./, '') <=> b.gsub(/\./, '') }
-puts 
+# puts 'items'
+# p items.sort.sort { |a, b| a.gsub(/\./, '') <=> b.gsub(/\./, '') }
+# puts 
 
 def cols_to_rows(cols)
   rows = []
@@ -53,27 +56,27 @@ def divide_to_cols(files)
       cols_size = files.size % n == 0 ? files.size / n : files.size / n + 1
       cols_size.times { cols << sliced.slice!(0, n) }
       cols = sizeup_to_max(cols)
-      puts "n:#{n}"
-      p cols
-      puts
+#       puts "n:#{n}"
+#       p cols
+#       puts
     end
   end
   cols
 end
 
-files = items.sort { |a, b| a.gsub(/\./, '') <=> b.gsub(/\./, '') }
+files = items.sort.sort { |a, b| a.gsub(/\./, '') <=> b.gsub(/\./, '') }
 
 cols = divide_to_cols(files)
 
-puts 'cols'
-p cols
-puts
-
+# puts 'cols'
+# p cols
+# puts
+# 
 rows = cols_to_rows(cols)
-
-puts 'rows'
-p rows
-puts
+# 
+# puts 'rows'
+# p rows
+# puts
 
 # p files.map { |e| e.size }.sum
 rows.each { |e| puts e.join('  ') }

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -20,7 +20,7 @@ def run_app
   end
   
   files = apply_order_option(items, a, r)
-  l ? list_detail(files) : list_name(files) 
+  l ? list_detail(path, files) : list_name(files) 
 end
 
 def apply_order_option(items, a, r)
@@ -30,12 +30,27 @@ def apply_order_option(items, a, r)
   files
 end
  
-def list_detail(files)
-  stat = File.stat("/home/kasai441/.b*")
-  puts stat.dev
-  puts stat.size
-  puts "0%o" % stat.mode
-  puts stat.mode
+def list_detail(path, files)
+  path = './' if !path
+  path += '/' if !path.match?(/.*\/$/)
+  data = []
+  blocks = 0
+  files.each do |f|
+    datum = []
+    stat = File.stat(path + f)
+    mode = "0%o" % stat.mode
+    datum << mode
+    datum << stat.uid
+    datum << stat.uid
+    datum << stat.size
+    datum << stat.mtime
+    datum << f
+    datum << stat.blocks
+    data << datum.join(' ')
+    blocks += stat.blocks
+  end
+  puts "total #{blocks}"
+  puts data
 end
 
 def list_name(files)

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -24,6 +24,7 @@ end
 
 def file_name(items, a, r)
   files = items.sort.sort { |a, b| a.gsub(/\./, '').downcase <=> b.gsub(/\./, '').downcase }
+  files.delete_if { |f| f.match?(/^\..*/) } if !a
   files.reverse! if r  
   cols = divide_to_cols(files)
   rows = cols_to_rows(cols)

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,8 +1,79 @@
-# Dir.foreach('.') do |item|
 path = ARGV[0]
+p path
+path = "#{Dir.home}" if path.nil?
+items = []
+files = []
+row = []
+
 Dir.open(path) do |d|
   d.children.each do |item|
-    print item + "\t"
+    items << item
   end
 end
+
+puts 'items'
+p items.sort { |a, b| a.gsub(/\./, '') <=> b.gsub(/\./, '') }
+puts 
+
+def cols_to_rows(cols)
+  rows = []
+  cols[0].size.times { |n| rows[n] = [] }
+
+  cols.each do |col|
+    col.each_with_index do |file, row_idx|
+      rows[row_idx] << file
+    end
+  end
+  rows
+end
+
+def within_width?(rows)
+  width = `tput cols`.gsub(/\D/, '').to_i
+  rows.each do |row|
+    return false if row.join('  ').size > width
+  end
+  true
+end
+
+def divide_to_cols(files)
+  cols = files.map { |e| [e] }
+  (2..files.size).each do |n|
+    unless within_width?(cols_to_rows(cols))
+      sliced = files.dup
+      cols.clear
+      cols_size = files.size % n == 0 ? files.size / n : files.size / n + 1
+      cols_size.times { cols << sliced.slice!(0, n) }
+      puts "n:#{n}"
+      p cols
+      puts
+    end
+  end
+  cols
+end
+
+files = items.sort { |a, b| a.gsub(/\./, '') <=> b.gsub(/\./, '') }
+
+cols = divide_to_cols(files)
+
+puts 'cols'
+p cols
+puts
+
+rows = cols_to_rows(cols)
+
+puts 'rows'
+p rows
+puts
+
+# p files.map { |e| e.size }.sum
+rows.each { |e| puts e.join('  ') }
+#    printf("%1$s  ", item)
+#    row += "  #{item}" if item.size   
 print "\n"
+p `tput cols`.gsub(/\D/, '').to_i
+
+stat = File.stat("/home/kasai441/#{items[0]}")
+puts stat.dev
+puts stat.size
+puts "0%o" % stat.mode
+puts stat.mode

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,24 +1,32 @@
-def run
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+
+def run_app
+  a = false
+  r = false
+  l = false
+  opt = OptionParser.new
+  opt.on('-a') { a = true }
+  opt.on('-r') { r = true }
+  opt.on('-l') { l = true }
+  opt.parse!(ARGV)
+
   path = ARGV[0]
-  p path
   items = []
-  # files = []
-  row = []
-  
   Dir.foreach(path || '.') do |d|
     items << d
   end
-  
-  file_name(items,0,0)
+
+  file_name(items, a, r) 
 end
 
 def file_name(items, a, r)
   files = items.sort.sort { |a, b| a.gsub(/\./, '').downcase <=> b.gsub(/\./, '').downcase }
-  
+  files.reverse! if r  
   cols = divide_to_cols(files)
-  
   rows = cols_to_rows(cols)
-  
   rows.each { |e| puts e.join('  ') }
 end
 
@@ -65,10 +73,12 @@ def sizeup_to_max(cols)
   result
 end
 
-run
+run_app
 
-stat = File.stat("/home/kasai441/#{items[0]}")
-puts stat.dev
-puts stat.size
-puts "0%o" % stat.mode
-puts stat.mode
+def stat
+  stat = File.stat("/home/kasai441/.b*")
+  puts stat.dev
+  puts stat.size
+  puts "0%o" % stat.mode
+  puts stat.mode
+end

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -38,8 +38,7 @@ def list_detail(path, files)
   files.each do |f|
     datum = []
     stat = File.stat(path + f)
-    mode = "0%o" % stat.mode
-    datum << mode
+    datum << to_char_ftype(stat.ftype) + to_char_mode(stat.mode)
     datum << stat.uid
     datum << stat.uid
     datum << stat.size
@@ -51,6 +50,38 @@ def list_detail(path, files)
   end
   puts "total #{blocks}"
   puts data
+end
+
+def to_char_ftype(ftype)
+  {
+    "file": "-",
+    "directory": "d",
+    "characterSpecial": "c",
+    "blockSpecial": "b",
+    "fifo": "p",
+    "link": "l",
+    "socket": "s",
+    "unknown": "?"
+  }[ftype.to_sym]
+end
+
+def to_char_mode(mode)
+  mode = "0%o" % mode
+  mode = mode[-3, 3]
+  mode = mode.split('').map { |m| which_mode(m) }.join
+end
+
+def which_mode(m)
+  {
+    "0": "---",
+    "1": "--x",
+    "2": "-w-",
+    "3": "-wx",
+    "4": "r--",
+    "5": "r-x",
+    "6": "rw-",
+    "7": "rwx"
+  }[m.to_sym]
 end
 
 def list_name(files)


### PR DESCRIPTION
Debian10/bashのlsの仕様を基本としました

### ローカル環境
- Debian GNU/Linux 10.7 / Ruby2.7.1
- MacOS Catalina ver 10.15.7 / Ruby3.0.0
### -l以外の出力
- 列を最大文字列幅に揃え、列間隔は空白2文字
- 表示しているターミナルのディスプレイ幅を超えた場合、等分で改行（2等分ではみ出る場合は3等分...4等分と全等分まで改行幅を変えて表示します）
- Macのlsとは出力形式に差異があります
### リンクのファイルタイプ非検出
- リンクのファイルタイプはディレクトリとして検知されるパターンが多く確認されましたが、RubyのFile::Statライブラリの動作に準じます
### ブロック数の違い
- Debian10のlsと比較してブロック数が2分の1になります。Macのlsとは同じです
- ファイルタイプがおそらくリンクの時、lsコマンドはブロック数を検知しませんが、本プログラムではブロック数はカウントされるため差異があります
### ソート
- Debian10は"."や大文字小文字を無視してソートしますが、Macでは考慮されます。本プログラムではDebian10と同様のソートをします
